### PR TITLE
Use absolute rlkit path

### DIFF
--- a/rlkit/core/__init__.py
+++ b/rlkit/core/__init__.py
@@ -1,7 +1,7 @@
 """
 General classes, functions, utilities that are used throughout rlkit.
 """
-from external.rlkit.rlkit.core.logging import logger
+from rlkit.core.logging import logger
 
 __all__ = ['logger']
 

--- a/rlkit/core/batch_rl_algorithm.py
+++ b/rlkit/core/batch_rl_algorithm.py
@@ -1,9 +1,9 @@
 import abc
 
 import gtimer as gt
-from external.rlkit.rlkit.core.rl_algorithm import BaseRLAlgorithm
-from external.rlkit.rlkit.data_management.replay_buffer import ReplayBuffer
-from external.rlkit.rlkit.samplers.data_collector import PathCollector
+from rlkit.core.rl_algorithm import BaseRLAlgorithm
+from rlkit.data_management.replay_buffer import ReplayBuffer
+from rlkit.samplers.data_collector import PathCollector
 
 
 class BatchRLAlgorithm(BaseRLAlgorithm, metaclass=abc.ABCMeta):

--- a/rlkit/core/eval_util.py
+++ b/rlkit/core/eval_util.py
@@ -7,7 +7,7 @@ from numbers import Number
 
 import numpy as np
 
-import external.rlkit.rlkit.pythonplusplus as ppp
+import rlkit.pythonplusplus as ppp
 
 
 def get_generic_path_information(paths, stat_prefix=''):

--- a/rlkit/core/logging.py
+++ b/rlkit/core/logging.py
@@ -17,7 +17,7 @@ import pickle
 import errno
 import torch
 
-from external.rlkit.rlkit.core.tabulate import tabulate
+from rlkit.core.tabulate import tabulate
 from collections import OrderedDict
 
 def add_prefix(log_dict: OrderedDict, prefix: str, divider=''):

--- a/rlkit/core/online_rl_algorithm.py
+++ b/rlkit/core/online_rl_algorithm.py
@@ -1,9 +1,9 @@
 import abc
 
 import gtimer as gt
-from external.rlkit.rlkit.core.rl_algorithm import BaseRLAlgorithm
-from external.rlkit.rlkit.data_management.replay_buffer import ReplayBuffer
-from external.rlkit.rlkit.samplers.data_collector import (
+from rlkit.core.rl_algorithm import BaseRLAlgorithm
+from rlkit.data_management.replay_buffer import ReplayBuffer
+from rlkit.samplers.data_collector import (
     PathCollector,
     StepCollector,
 )

--- a/rlkit/core/rl_algorithm.py
+++ b/rlkit/core/rl_algorithm.py
@@ -3,9 +3,9 @@ from collections import OrderedDict
 
 import gtimer as gt
 
-from external.rlkit.rlkit.core import logger, eval_util
-from external.rlkit.rlkit.data_management.replay_buffer import ReplayBuffer
-from external.rlkit.rlkit.samplers.data_collector import DataCollector
+from rlkit.core import logger, eval_util
+from rlkit.data_management.replay_buffer import ReplayBuffer
+from rlkit.samplers.data_collector import DataCollector
 
 
 def _get_epoch_timings():

--- a/rlkit/data_management/env_replay_buffer.py
+++ b/rlkit/data_management/env_replay_buffer.py
@@ -1,7 +1,7 @@
 from gym.spaces import Discrete
 
-from external.rlkit.rlkit.data_management.simple_replay_buffer import SimpleReplayBuffer
-from external.rlkit.rlkit.envs.env_utils import get_dim
+from rlkit.data_management.simple_replay_buffer import SimpleReplayBuffer
+from rlkit.envs.env_utils import get_dim
 import numpy as np
 
 

--- a/rlkit/data_management/obs_dict_replay_buffer.py
+++ b/rlkit/data_management/obs_dict_replay_buffer.py
@@ -1,7 +1,7 @@
 import numpy as np
 from gym.spaces import Dict, Discrete
 
-from external.rlkit.rlkit.data_management.replay_buffer import ReplayBuffer
+from rlkit.data_management.replay_buffer import ReplayBuffer
 
 
 class ObsDictRelabelingBuffer(ReplayBuffer):

--- a/rlkit/data_management/online_vae_replay_buffer.py
+++ b/rlkit/data_management/online_vae_replay_buffer.py
@@ -1,13 +1,13 @@
 import numpy as np
 
-import external.rlkit.rlkit.torch.pytorch_util as ptu
+import rlkit.torch.pytorch_util as ptu
 from multiworld.core.image_env import normalize_image
-from external.rlkit.rlkit.core.eval_util import create_stats_ordered_dict
-from external.rlkit.rlkit.data_management.obs_dict_replay_buffer import flatten_dict
-from external.rlkit.rlkit.data_management.shared_obs_dict_replay_buffer import \
+from rlkit.core.eval_util import create_stats_ordered_dict
+from rlkit.data_management.obs_dict_replay_buffer import flatten_dict
+from rlkit.data_management.shared_obs_dict_replay_buffer import \
     SharedObsDictRelabelingBuffer
-from external.rlkit.rlkit.envs.vae_wrapper import VAEWrappedEnv
-from external.rlkit.rlkit.torch.vae.vae_trainer import (
+from rlkit.envs.vae_wrapper import VAEWrappedEnv
+from rlkit.torch.vae.vae_trainer import (
     compute_p_x_np_to_np,
     relative_probs_from_log_probs,
 )

--- a/rlkit/data_management/shared_obs_dict_replay_buffer.py
+++ b/rlkit/data_management/shared_obs_dict_replay_buffer.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from external.rlkit.rlkit.data_management.obs_dict_replay_buffer import ObsDictRelabelingBuffer
+from rlkit.data_management.obs_dict_replay_buffer import ObsDictRelabelingBuffer
 
 import torch.multiprocessing as mp
 import ctypes

--- a/rlkit/data_management/simple_replay_buffer.py
+++ b/rlkit/data_management/simple_replay_buffer.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import numpy as np
 import warnings
 
-from external.rlkit.rlkit.data_management.replay_buffer import ReplayBuffer
+from rlkit.data_management.replay_buffer import ReplayBuffer
 import pdb
 
 class SimpleReplayBuffer(ReplayBuffer):
@@ -75,7 +75,7 @@ class SimpleReplayBuffer(ReplayBuffer):
         indices = np.random.choice(self._size, size=batch_size, replace=self._replace or self._size < batch_size)
         if not self._replace and self._size < batch_size:
             warnings.warn('Replace was set to false, but is temporarily set to true because batch size is larger than current size of replay.')
-        pdb.set_trace()
+        # pdb.set_trace()
         batch = dict(
             observations=self._observations[indices],
             actions=self._actions[indices],

--- a/rlkit/data_management/split_buffer.py
+++ b/rlkit/data_management/split_buffer.py
@@ -1,6 +1,6 @@
 import random
 
-from external.rlkit.rlkit.data_management.replay_buffer import ReplayBuffer
+from rlkit.data_management.replay_buffer import ReplayBuffer
 
 
 class SplitReplayBuffer(ReplayBuffer):

--- a/rlkit/samplers/data_collector/__init__.py
+++ b/rlkit/samplers/data_collector/__init__.py
@@ -1,14 +1,14 @@
-from external.rlkit.rlkit.samplers.data_collector.base import (
+from rlkit.samplers.data_collector.base import (
     DataCollector,
     PathCollector,
     StepCollector,
 )
-from external.rlkit.rlkit.samplers.data_collector.path_collector import (
+from rlkit.samplers.data_collector.path_collector import (
     MdpPathCollector,
     ObsDictPathCollector,
     GoalConditionedPathCollector,
     VAEWrappedEnvPathCollector,
 )
-from external.rlkit.rlkit.samplers.data_collector.step_collector import (
+from rlkit.samplers.data_collector.step_collector import (
     GoalConditionedStepCollector
 )

--- a/rlkit/samplers/data_collector/path_collector.py
+++ b/rlkit/samplers/data_collector/path_collector.py
@@ -3,9 +3,9 @@ from functools import partial
 
 import numpy as np
 
-from external.rlkit.rlkit.core.eval_util import create_stats_ordered_dict
-from external.rlkit.rlkit.samplers.data_collector.base import PathCollector
-from external.rlkit.rlkit.samplers.rollout_functions import rollout
+from rlkit.core.eval_util import create_stats_ordered_dict
+from rlkit.samplers.data_collector.base import PathCollector
+from rlkit.samplers.rollout_functions import rollout
 import pdb
 
 class MdpPathCollector(PathCollector):

--- a/rlkit/torch/networks/mlp.py
+++ b/rlkit/torch/networks/mlp.py
@@ -2,13 +2,13 @@ import torch
 from torch import nn
 from torch.nn import functional as F
 
-from external.rlkit.rlkit.policies.base import Policy
-from external.rlkit.rlkit.pythonplusplus import identity
-from external.rlkit.rlkit.torch import pytorch_util as ptu
-from external.rlkit.rlkit.torch.core import PyTorchModule, eval_np
-from external.rlkit.rlkit.torch.data_management.normalizer import TorchFixedNormalizer
-from external.rlkit.rlkit.torch.networks import LayerNorm
-from external.rlkit.rlkit.torch.pytorch_util import activation_from_string
+from rlkit.policies.base import Policy
+from rlkit.pythonplusplus import identity
+from rlkit.torch import pytorch_util as ptu
+from rlkit.torch.core import PyTorchModule, eval_np
+from rlkit.torch.data_management.normalizer import TorchFixedNormalizer
+from rlkit.torch.networks import LayerNorm
+from rlkit.torch.pytorch_util import activation_from_string
 import pdb
 
 class Mlp(PyTorchModule):

--- a/rlkit/torch/sac/policies/__init__.py
+++ b/rlkit/torch/sac/policies/__init__.py
@@ -1,9 +1,9 @@
-from external.rlkit.rlkit.torch.sac.policies.base import (
+from rlkit.torch.sac.policies.base import (
     TorchStochasticPolicy,
     PolicyFromDistributionGenerator,
     MakeDeterministic,
 )
-from external.rlkit.rlkit.torch.sac.policies.gaussian_policy import (
+from rlkit.torch.sac.policies.gaussian_policy import (
     TanhGaussianPolicyAdapter,
     TanhGaussianPolicy,
     GaussianPolicy,
@@ -13,8 +13,8 @@ from external.rlkit.rlkit.torch.sac.policies.gaussian_policy import (
     TanhGaussianObsProcessorPolicy,
     TanhCNNGaussianPolicy,
 )
-from external.rlkit.rlkit.torch.sac.policies.lvm_policy import LVMPolicy
-from external.rlkit.rlkit.torch.sac.policies.policy_from_q import PolicyFromQ
+from rlkit.torch.sac.policies.lvm_policy import LVMPolicy
+from rlkit.torch.sac.policies.policy_from_q import PolicyFromQ
 
 
 __all__ = [

--- a/rlkit/torch/torch_rl_algorithm.py
+++ b/rlkit/torch/torch_rl_algorithm.py
@@ -4,10 +4,10 @@ from collections import OrderedDict
 from typing import Iterable
 from torch import nn as nn
 
-from external.rlkit.rlkit.core.batch_rl_algorithm import BatchRLAlgorithm
-from external.rlkit.rlkit.core.online_rl_algorithm import OnlineRLAlgorithm
-from external.rlkit.rlkit.core.trainer import Trainer
-from external.rlkit.rlkit.torch.core import np_to_pytorch_batch
+from rlkit.core.batch_rl_algorithm import BatchRLAlgorithm
+from rlkit.core.online_rl_algorithm import OnlineRLAlgorithm
+from rlkit.core.trainer import Trainer
+from rlkit.torch.core import np_to_pytorch_batch
 
 
 class TorchOnlineRLAlgorithm(OnlineRLAlgorithm):


### PR DESCRIPTION
This solves the circular dependency issue.

Need to add this path into PYTHONPATH. Will add a note in README